### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,24 @@ matrix:
     - cmake . -DENABLE_TESTS=1
     - make VERBOSE=1
     - make VERBOSE=1 check
+  - os: linux
+    dist: xenial
+    arch: ppc64le
+    addons:
+      apt:
+        packages:
+        - cmake
+        - libboost-dev
+        - libboost-filesystem-dev
+        - libboost-locale-dev
+        - libtag1-dev
+        - libcue-dev
+        - libedit-dev
+        - pkg-config
+    script:
+    - cmake . -DENABLE_TESTS=1
+    - make VERBOSE=1
+    - make VERBOSE=1 check
 
   - os: osx
     addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c++
-
+ 
 matrix:
   include:
   - os: linux


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.